### PR TITLE
Update crt-geom.slang

### DIFF
--- a/crt/crt-geom.slang
+++ b/crt/crt-geom.slang
@@ -12,7 +12,7 @@ layout(std140, set = 0, binding = 0) uniform UBO
 #define CRTgamma 2.4
 #define monitorgamma 2.2
 #define d 1.5
-//#define CURVATURE 1.0
+#define CURVATURE 1.0
 #define R 2.0
 #define cornersize 0.03
 #define cornersmooth 1000.0
@@ -71,7 +71,6 @@ layout(std140, set = 0, binding = 0) uniform UBO
 
 // aspect ratio
 vec2 aspect     = vec2(1.0,  0.75);
-vec2 angle      = vec2(0.0,  0.0);
 vec2 overscan   = vec2(1.01, 1.01);
 
 #pragma stage vertex
@@ -84,6 +83,7 @@ layout(location = 3) out vec3 stretch;
 layout(location = 4) out vec2 ilfac;
 layout(location = 5) out vec2 one;
 layout(location = 6) out float mod_factor;
+layout(location = 7) out vec2 TextureSize;
 
 float intersect(vec2 xy)
 {
@@ -96,20 +96,18 @@ float intersect(vec2 xy)
 
 vec2 bkwtrans(vec2 xy)
 {
-    float c = intersect(xy);
-    vec2 point = vec2(c)*xy;
-    point -= vec2(-R)*sinangle;
-    point /= vec2(R);
-    vec2 tang = sinangle/cosangle;
-    vec2 poc = point/cosangle;
+    float c     = intersect(xy);
+    vec2 point  = (vec2(c, c)*xy - vec2(-R, -R)*sinangle) / vec2(R, R);
+    vec2 poc    = point/cosangle;
     
-    float A = dot(tang,tang)+1.0;
-    float B = -2.0*dot(poc,tang);
-    float C = dot(poc,poc)-1.0;
+    vec2 tang   = sinangle/cosangle;
+    float A     = dot(tang, tang) + 1.0;
+    float B     = -2.0*dot(poc, tang);
+    float C     = dot(poc, poc) - 1.0;
     
-    float a = (-B+sqrt(B*B-4.0*A*C))/(2.0*A);
-    vec2 uv = (point-a*sinangle)/cosangle;
-    float r = R*acos(a);
+    float a     = (-B + sqrt(B*B - 4.0*A*C))/(2.0*A);
+    vec2 uv     = (point - a*sinangle)/cosangle;
+    float r     = R*acos(a);
     
     return uv*r/sin(r/R);
 }
@@ -128,10 +126,12 @@ vec3 maxscale()
 {
     vec2 c  = bkwtrans(-R * sinangle / (1.0 + R/d*cosangle.x*cosangle.y));
     vec2 a  = vec2(0.5,0.5)*aspect;
-    vec2 lo = vec2(fwtrans(vec2(-a.x,c.y)).x,
-             fwtrans(vec2(c.x,-a.y)).y)/aspect;
-    vec2 hi = vec2(fwtrans(vec2(+a.x,c.y)).x,
-             fwtrans(vec2(c.x,+a.y)).y)/aspect;
+    
+    vec2 lo = vec2(fwtrans(vec2(-a.x,  c.y)).x,
+                   fwtrans(vec2( c.x, -a.y)).y)/aspect;
+
+    vec2 hi = vec2(fwtrans(vec2(+a.x,  c.y)).x,
+                   fwtrans(vec2( c.x, +a.y)).y)/aspect;
     
     return vec3((hi+lo)*aspect*0.5,max(hi.x-lo.x,hi.y-lo.y));
 }
@@ -174,14 +174,19 @@ void main()
 
     // Precalculate a bunch of useful values we'll need in the fragment
     // shader.
-    sinangle = sin(angle);
-    cosangle = cos(angle);
-    stretch  = maxscale();
-
-    ilfac = vec2(1.0, 1.0000001);//vec2(1.0,(global.SourceSize.y/200.0));
+    sinangle    = sin(vec2(x_tilt, y_tilt));
+    cosangle    = cos(vec2(x_tilt, y_tilt));
+    stretch     = maxscale();
+    TextureSize = vec2(SHARPER * global.SourceSize.x, global.SourceSize.y);
+    
+#ifdef INTERLACED
+    ilfac = vec2(1.0, clamp(floor(global.SourceSize.y/200.0),  1.0, 2.0));
+#else
+    ilfac = vec2(1.0, clamp(floor(global.SourceSize.y/1000.0), 1.0, 2.0));
+#endif
 
     // The size of one texel, in texture-coordinates.
-    one = ilfac / global.SourceSize.xy;
+    one = ilfac / TextureSize;
 
     // Resulting X pixel-coordinate of the pixel we're drawing.
     mod_factor = vTexCoord.x * global.SourceSize.x * global.OutputSize.x / global.SourceSize.x;
@@ -195,13 +200,14 @@ layout(location = 3) in vec3 stretch;
 layout(location = 4) in vec2 ilfac;
 layout(location = 5) in vec2 one;
 layout(location = 6) in float mod_factor;
+layout(location = 7) in vec2 TextureSize;
 layout(location = 0) out vec4 FragColor;
 layout(set = 0, binding = 2) uniform sampler2D Source;
 
 float intersect(vec2 xy)
 {
     float A = dot(xy,xy) + d*d;
-    float B = 2.0*(R*(dot(xy,sinangle)-d*cosangle.x*cosangle.y) - d*d);
+    float B = 2.0*(R*(dot(xy,sinangle) - d*cosangle.x*cosangle.y) - d*d);
     float C = d*d + 2.0*R*d*cosangle.x*cosangle.y;
     
     return (-B-sqrt(B*B - 4.0*A*C))/(2.0*A);
@@ -209,45 +215,41 @@ float intersect(vec2 xy)
 
 vec2 bkwtrans(vec2 xy)
 {
-    float c = intersect(xy);
-    vec2 point = vec2(c)*xy;
+    float c     = intersect(xy);
+    vec2 point  = (vec2(c, c)*xy - vec2(-R, -R)*sinangle) / vec2(R, R);
+    vec2 poc    = point/cosangle;
+    vec2 tang   = sinangle/cosangle;
 
-    point -= vec2(-R)*sinangle;
-    point /= vec2(R);
+    float A     = dot(tang, tang) + 1.0;
+    float B     = -2.0*dot(poc, tang);
+    float C     = dot(poc, poc) - 1.0;
 
-    vec2 tang = sinangle/cosangle;
-    vec2 poc = point/cosangle;
-
-    float A = dot(tang,tang)+1.0;
-    float B = -2.0*dot(poc,tang);
-    float C = dot(poc,poc)-1.0;
-
-    float a = (-B+sqrt(B*B-4.0*A*C))/(2.0*A);
-    vec2 uv = (point-a*sinangle)/cosangle;
-    float r = R*acos(a);
+    float a     = (-B + sqrt(B*B - 4.0*A*C)) / (2.0*A);
+    vec2 uv     = (point - a*sinangle) / cosangle;
+    float r     = R*acos(a);
     
     return uv*r/sin(r/R);
 }
 
 vec2 fwtrans(vec2 uv)
 {
-    float r = FIX(sqrt(dot(uv,uv)));
+    float r = FIX(sqrt(dot(uv, uv)));
     uv *= sin(r/R)/r;
-    float x = 1.0-cos(r/R);
+    float x = 1.0 - cos(r/R);
     float D = d/R + x*cosangle.x*cosangle.y + dot(uv,sinangle);
 
-    return d*(uv*cosangle-x*sinangle)/D;
+    return d*(uv*cosangle - x*sinangle)/D;
 }
 
 vec3 maxscale()
 {
     vec2 c = bkwtrans(-R * sinangle / (1.0 + R/d*cosangle.x*cosangle.y));
-    vec2 a = vec2(0.5,0.5)*aspect;
+    vec2 a = vec2(0.5, 0.5)*aspect;
 
-    vec2 lo = vec2(fwtrans(vec2(-a.x,c.y)).x,
-             fwtrans(vec2(c.x, -a.y)).y)/aspect;
-    vec2 hi = vec2(fwtrans(vec2(+a.x,c.y)).x,
-             fwtrans(vec2(c.x, +a.y)).y)/aspect;
+    vec2 lo = vec2(fwtrans(vec2(-a.x,  c.y)).x,
+                   fwtrans(vec2( c.x, -a.y)).y)/aspect;
+    vec2 hi = vec2(fwtrans(vec2(+a.x,  c.y)).x,
+                   fwtrans(vec2( c.x, +a.y)).y)/aspect;
 
     return vec3((hi+lo)*aspect*0.5,max(hi.x-lo.x, hi.y-lo.y));
 }
@@ -283,22 +285,21 @@ vec4 scanlineWeights(float distance, vec4 color)
     
 vec2 transform(vec2 coord)
 {
-    coord *= global.SourceSize.xy;
-    coord = (coord-vec2(0.5))*aspect*stretch.z+stretch.xy;
+    coord = (coord - vec2(0.5, 0.5))*aspect*stretch.z + stretch.xy;
     
-    return (bkwtrans(coord)/vec2(overscan_x / 100.0, overscan_y / 100.0)/aspect+vec2(0.5)) * global.SourceSize.xy;
+    return (bkwtrans(coord) /
+        vec2(overscan_x / 100.0, overscan_y / 100.0)/aspect + vec2(0.5, 0.5));
 }
     
 float corner(vec2 coord)
 {
-//       coord *= global.SourceSize.xy / global.SourceSize.zw;
-    coord = (coord - vec2(0.5)) * vec2(overscan_x / 100.0, overscan_y / 100.0) + vec2(0.5);
+    coord = (coord - vec2(0.5)) * vec2(overscan_x / 100.0, overscan_y / 100.0) + vec2(0.5, 0.5);
     coord = min(coord, vec2(1.0) - coord) * aspect;
     vec2 cdist = vec2(cornersize);
     coord = (cdist - min(coord, cdist));
     float dist = sqrt(dot(coord, coord));
     
-    return clamp((cdist.x-dist)*cornersmooth, 0.0, 1.0);
+    return clamp((cdist.x - dist)*cornersmooth, 0.0, 1.0);
 }
     
 void main()
@@ -330,6 +331,7 @@ void main()
 #else
     vec2 xy = vTexCoord;
 #endif
+
     float cval = corner(xy);
 
     // Of all the pixels that are mapped onto the texel we are
@@ -339,14 +341,12 @@ void main()
 #else
     vec2 ilvec = vec2(0.0, ilfac.y);
 #endif
-    vec2 ratio_scale = (xy * global.SourceSize.xy - vec2(0.5, 0.5) + ilvec)/ilfac;
-#ifdef OVERSAMPLE
-    float filter_ = fwidth(ratio_scale.y);//global.SourceSize.y / global.OutputSize.y;
-#endif
+
+    vec2 ratio_scale = (xy * TextureSize - vec2(0.5, 0.5) + ilvec) / ilfac;
     vec2 uv_ratio = fract(ratio_scale);
 
     // Snap to the center of the underlying texel.
-    xy = (floor(ratio_scale)*ilfac + vec2(0.5, 0.5) - ilvec) / global.SourceSize.xy;
+    xy = (floor(ratio_scale)*ilfac + vec2(0.5, 0.5) - ilvec) / TextureSize;
 
     // Calculate Lanczos scaling coefficients describing the effect
     // of various neighbour texels in a scanline on the current
@@ -393,14 +393,17 @@ void main()
     // the current pixel.
     vec4 weights  = scanlineWeights(uv_ratio.y, col);
     vec4 weights2 = scanlineWeights(1.0 - uv_ratio.y, col2);
+
 #ifdef OVERSAMPLE
-    uv_ratio.y  = uv_ratio.y + 1.0/3.0*filter_;
-    weights     = (weights  + scanlineWeights(uv_ratio.y, col))/3.0;
-    weights2    = (weights2 + scanlineWeights(abs(1.0-uv_ratio.y), col2))/3.0;
-    uv_ratio.y  = uv_ratio.y - 2.0/3.0*filter_;
-    weights     = weights  + scanlineWeights(abs(uv_ratio.y), col)/3.0;
-    weights2    = weights2 + scanlineWeights(abs(1.0-uv_ratio.y), col2)/3.0;
+    float filter_ = fwidth(ratio_scale.y);
+    uv_ratio.y    = uv_ratio.y + 1.0/3.0*filter_;
+    weights       = (weights  + scanlineWeights(uv_ratio.y, col))/3.0;
+    weights2      = (weights2 + scanlineWeights(abs(1.0 - uv_ratio.y), col2))/3.0;
+    uv_ratio.y    = uv_ratio.y - 2.0/3.0*filter_;
+    weights       = weights  + scanlineWeights(abs(uv_ratio.y), col)/3.0;
+    weights2      = weights2 + scanlineWeights(abs(1.0 - uv_ratio.y), col2)/3.0;
 #endif
+
     vec3 mul_res  = (col * weights + col2 * weights2).rgb * vec3(cval);
 
     // dot-mask emulation:


### PR DESCRIPTION
CURVATURE is now working. The problem was due to the replacement of `IN.video_size / IN.texture_size` (a small number representing the scale between the two sizes) with `global.SourceSize.xy` (much bigger than the previous number).

SHARPER was made to work too.

@hizzlekizzle: I deleted your `vec2 angle` variable, which was hardcoded to (0, 0) while I was trying to fix the curvature stuff. Feel free to revert that.