### PR TITLE
(interlacing) Minor fix for 480 line games

### DIFF
--- a/misc/interlacing.slang
+++ b/misc/interlacing.slang
@@ -44,7 +44,7 @@ void main()
    float y = 0.0;
 
    // assume anything with a vertical resolution greater than 400 lines is interlaced
-   if (global.SourceSize.w > 400.0)
+   if (global.SourceSize.y > 400.0)
    {y = global.SourceSize.y * vTexCoord.y + (global.FrameCount * enable_480i) + top_field_first;}
    else
    {y = 2.0 * global.SourceSize.y * vTexCoord.y + top_field_first;}


### PR DESCRIPTION
The actual interlacing still does not work, but at least it can now display 480 line games as 240p instead of [this](https://a.pomf.cat/scdemb.png)

It seems that global.FrameCount does not work the same way the Cg spec's IN.frame_count does.